### PR TITLE
Fixed denied access.

### DIFF
--- a/cleverbot/cleverbot.py
+++ b/cleverbot/cleverbot.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 from builtins import str  # pylint: disable=redefined-builtin
 from builtins import object  # pylint: disable=redefined-builtin
 
+import collections
 import hashlib
 import requests
 from requests.compat import urlencode
@@ -43,31 +44,37 @@ class Cleverbot(object):
 
     def __init__(self):
         """ The data that will get passed to Cleverbot's web API """
-        self.data = {
-            'stimulus': '',
-            'start': 'y',  # Never modified
-            'sessionid': '',
-            'vText8': '',
-            'vText7': '',
-            'vText6': '',
-            'vText5': '',
-            'vText4': '',
-            'vText3': '',
-            'vText2': '',
-            'icognoid': 'wsf',  # Never modified
-            'icognocheck': '',
-            'fno': 0,  # Never modified
-            'prevref': '',
-            'emotionaloutput': '',  # Never modified
-            'emotionalhistory': '',  # Never modified
-            'asbotname': '',  # Never modified
-            'ttsvoice': '',  # Never modified
-            'typing': '',  # Never modified
-            'lineref': '',
-            'sub': 'Say',  # Never modified
-            'islearning': 1,  # Never modified
-            'cleanslate': False,  # Never modified
-        }
+        self.data = collections.OrderedDict(
+            (
+                # must be the first pairs
+                ('stimulus', ''),
+                ('cb_settings_language', ''),
+                ('cb_settings_scripting', 'no'),
+                ('islearning', 1),  # Never modified
+                ('icognoid', 'wsf'),  # Never modified
+                ('icognocheck', ''),
+
+                ('start', 'y'),  # Never modified
+                ('sessionid', ''),
+                ('vText8', ''),
+                ('vText7', ''),
+                ('vText6', ''),
+                ('vText5', ''),
+                ('vText4', ''),
+                ('vText3', ''),
+                ('vText2', ''),
+                ('fno', 0),  # Never modified
+                ('prevref', ''),
+                ('emotionaloutput', ''),  # Never modified
+                ('emotionalhistory', ''),  # Never modified
+                ('asbotname', ''),  # Never modified
+                ('ttsvoice', ''),  # Never modified
+                ('typing', ''),  # Never modified
+                ('lineref', ''),
+                ('sub', 'Say'),  # Never modified
+                ('cleanslate', False),  # Never modified
+            )
+        )
 
         # the log of our conversation with Cleverbot
         self.conversation = []
@@ -152,7 +159,6 @@ class Cleverbot(object):
         parsed_dict = {
             'answer': parsed[0][0],
             'conversation_id': parsed[0][1],
-            'conversation_log_id': parsed[0][2],
         }
         try:
             parsed_dict['unknown'] = parsed[1][-1]


### PR DESCRIPTION
I tried to reverse http://www.cleverbot.com/extras/conversation-social-min.js

The first parameters sent were `stimulus={question_content}&cb_settings_language=&cb_settings_scripting=no&islearning=1&icognoid=wsf&icognocheck=`. Then, the token is the md5 checksum of the 10th through 36th characters of the data (not changed).

So, the idea was to put an OrderedDict instead of a simple dictionary in Cleverbot.data. And... Tada! I just needed to remove the key "conversation_log_id" in Cleverbot._parse() that was no longer sent by cleverbot.

I hope it could help this project