### PR TITLE
Fixed denied access.

### DIFF
--- a/cleverbot/cleverbot.py
+++ b/cleverbot/cleverbot.py
@@ -27,7 +27,7 @@ class Cleverbot(object):
     """
     HOST = "www.cleverbot.com"
     PROTOCOL = "http://"
-    RESOURCE = "/webservicemin"
+    RESOURCE = "/webservicemin?uc=165&"
     API_URL = PROTOCOL + HOST + RESOURCE
 
     headers = {


### PR DESCRIPTION
Looking at http://www.cleverbot.com/extras/conversation-social-min.js I found they added `?uc=165&` after the /webservicemin in the url. This little change broke the requests and should now be fixed again.