### PR TITLE
Fixed denied access and added botapi parameter

### DIFF
--- a/cleverbot/cleverbot.py
+++ b/cleverbot/cleverbot.py
@@ -27,8 +27,9 @@ class Cleverbot(object):
     """
     HOST = "www.cleverbot.com"
     PROTOCOL = "http://"
-    RESOURCE = "/webservicemin?uc=321&"
-    API_URL = PROTOCOL + HOST + RESOURCE
+    RESOURCE = "/webservicemin?uc=3210&"
+    BOT_API = "&botapi=cleverbot-py"
+    API_URL = PROTOCOL + HOST + RESOURCE + BOT_API
 
     headers = {
         'User-Agent': 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0)',


### PR DESCRIPTION
Fixed the denied access problem by changing Resource to `RESOURCE = "/webservicemin?uc=3210&"` 
And adding the new &botapi=api_name parameter: `BOT_API = "&botapi=cleverbot_py"`

Big thanks to aurieh for pointing out the change, I thought I would add the `botapi` as a seperate variable for clearity (and easier editing).